### PR TITLE
Fix sparse-rowid bias in random verse selection

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -144,14 +144,14 @@ func makeRandomHandler(db *sql.DB) http.HandlerFunc {
 		row := db.QueryRow(`
 			SELECT text
 			FROM verses
-			WHERE rowid >= (
+			ORDER BY rowid
+			LIMIT 1 OFFSET (
 				SELECT CASE
-					WHEN max_rowid = 0 THEN 0
-					ELSE (ABS(RANDOM()) % max_rowid) + 1
+					WHEN verse_count = 0 THEN 0
+					ELSE ABS(RANDOM()) % verse_count
 				END
-				FROM (SELECT IFNULL(MAX(rowid), 0) AS max_rowid FROM verses)
-			)
-			LIMIT 1`)
+				FROM (SELECT COUNT(*) AS verse_count FROM verses)
+			)`)
 		var text string
 		if err := row.Scan(&text); err != nil {
 			if err == sql.ErrNoRows {

--- a/internal/api/handlers_more_test.go
+++ b/internal/api/handlers_more_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/minh/daily-bible/internal/model"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/minh/daily-bible/internal/model"
 )
 
 func TestGetGospel_ValidAndErrors(t *testing.T) {
@@ -228,6 +228,44 @@ func TestSearchHandler_EmptyResults(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("expected empty array for no matches, got %v", got)
+	}
+}
+
+func TestRandomHandler_UsesUniformExistingRows(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	if _, err := db.Exec(`
+		INSERT INTO verses(rowid, book, chapter, verse, text)
+		VALUES
+			(1, 'Ga', 10, 31, 'first gap row'),
+			(1000, 'Ga', 10, 32, 'second gap row')`); err != nil {
+		t.Fatal(err)
+	}
+
+	h := makeRandomHandler(db)
+	req := httptest.NewRequest("GET", "/api/v1/random", nil)
+	counts := map[string]int{}
+
+	for range 200 {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 during random sampling, got %d", w.Code)
+		}
+
+		var got string
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatal(err)
+		}
+		counts[got]++
+	}
+
+	if counts["first gap row"] < 40 {
+		t.Fatalf("expected first sparse-row entry to be sampled repeatedly, got counts %v", counts)
+	}
+	if counts["second gap row"] < 40 {
+		t.Fatalf("expected second sparse-row entry to be sampled repeatedly, got counts %v", counts)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- The previous `/api/v1/random` query used a random `rowid` threshold which was biased when `rowid` values had gaps (e.g. after deletes), causing non-uniform sampling across existing verses.

### Description
- Replace the `rowid`-threshold query in `makeRandomHandler` with a `COUNT(*)` + `LIMIT 1 OFFSET` selection ordered by `rowid` to pick uniformly from existing rows in `internal/api/handlers.go`.
- Ensure the query uses `ORDER BY rowid` before applying the random offset so selection is across the actual row set rather than the numeric `rowid` space.
- Add a regression test `TestRandomHandler_UsesUniformExistingRows` in `internal/api/handlers_more_test.go` that inserts rows at sparse `rowid`s (1 and 1000) and samples the handler multiple times to verify both rows are returned repeatedly.

### Testing
- Ran the regression test with `go test -vet=off ./internal/api -run TestRandomHandler_UsesUniformExistingRows -count=1`, which passed.
- Ran the full test suite with `go test -vet=off ./...`, which also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab28f95b0832aae7e9b5e05972193)