### PR TITLE
Add /liveness and /readiness health endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,6 @@ Use `make help` to get more insight
 curl 'http://localhost:8080/api/v1/gospel/Ga%209,1-41'
 curl 'http://localhost:8080/api/v1/search?q=Ch%C3%BAa+Gi%C3%AA-su'
 curl 'http://localhost:8080/api/v1/random'
+curl 'http://localhost:8080/liveness'
+curl 'http://localhost:8080/readiness'
 ```

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -8,11 +8,32 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
 	"github.com/minh/daily-bible/internal/model"
 )
+
+func makeLivenessHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func makeReadinessHandler(dbPath string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, err := os.Stat(dbPath); err != nil {
+			if os.IsNotExist(err) {
+				http.Error(w, "database not ready", http.StatusServiceUnavailable)
+				return
+			}
+			http.Error(w, "readiness check failed", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}
 
 func makeGetGospelHandler(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers_more_test.go
+++ b/internal/api/handlers_more_test.go
@@ -5,12 +5,56 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/minh/daily-bible/internal/model"
 )
+
+func TestLivenessHandler(t *testing.T) {
+	h := makeLivenessHandler()
+	req := httptest.NewRequest("GET", "/liveness", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for liveness, got %d", w.Code)
+	}
+}
+
+func TestReadinessHandler(t *testing.T) {
+	t.Run("ready when db file exists", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "bible.db")
+		if err := os.WriteFile(dbPath, []byte("ready"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		h := makeReadinessHandler(dbPath)
+		req := httptest.NewRequest("GET", "/readiness", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 when db file exists, got %d", w.Code)
+		}
+	})
+
+	t.Run("not ready when db file is missing", func(t *testing.T) {
+		h := makeReadinessHandler(filepath.Join(t.TempDir(), "missing.db"))
+		req := httptest.NewRequest("GET", "/readiness", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503 when db file is missing, got %d", w.Code)
+		}
+	})
+}
 
 func TestGetGospel_ValidAndErrors(t *testing.T) {
 	// prefix not found (no DB usage required)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+
+	"github.com/minh/daily-bible/internal/constants"
 )
 
 // NewRouter initializes HTTP handlers and returns an http.Handler. Returns an error
@@ -15,6 +17,8 @@ func NewRouter(db *sql.DB) (http.Handler, error) {
 		return nil, fmt.Errorf("query max rowid: %w", err)
 	}
 	mux := http.NewServeMux()
+	mux.HandleFunc("/liveness", makeLivenessHandler())
+	mux.HandleFunc("/readiness", makeReadinessHandler(constants.DBPath))
 	mux.HandleFunc("/api/v1/gospel/", makeGetGospelHandler(db))
 	mux.HandleFunc("/api/v1/search", makeSearchHandler(db))
 	mux.HandleFunc("/api/v1/random", makeRandomHandler(db, maxRowID))

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -44,5 +46,37 @@ func TestNewRouter_RegistersHandlers_Ok(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 after insert, got %d", w.Code)
+	}
+}
+
+func TestNewRouter_HealthHandlers(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	buildDir := "build"
+	if err := os.MkdirAll(buildDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbFile := filepath.Join(buildDir, "bible.db")
+	if err := os.WriteFile(dbFile, []byte("ready"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(dbFile)
+
+	r, err := NewRouter(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for path, want := range map[string]int{
+		"/liveness":  http.StatusOK,
+		"/readiness": http.StatusOK,
+	} {
+		req := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != want {
+			t.Fatalf("expected %s to return %d, got %d", path, want, w.Code)
+		}
 	}
 }


### PR DESCRIPTION
### Motivation
- Provide lightweight Kubernetes-style probes so orchestration and monitoring systems can verify process liveness and application readiness.
- Readiness should reflect whether the application can serve requests that depend on the database file existing (DB path is `constants.DBPath`).

### Description
- Add `makeLivenessHandler` and `makeReadinessHandler` to `internal/api/handlers.go`, with readiness checking the DB file via the configured `DBPath` and returning `503` when missing.
- Wire the new routes into the router in `internal/api/router.go` at `/liveness` and `/readiness` using `makeReadinessHandler(constants.DBPath)`.
- Add handler-level tests in `internal/api/handlers_more_test.go` and router-level tests in `internal/api/router_test.go` to cover liveness, readiness (file exists/missing), and router registration.
- Update README E2E examples to document the new probe endpoints (`/liveness` and `/readiness`).

### Testing
- Ran `go test ./internal/api` and the API package tests passed (`ok`).
- Ran `go test ./internal/db ./tools/crawler ./tools/tsv` and those package tests passed (`ok`).
- Exercised the `./cmd/server` package where there are no test files, and targeted package tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c81c70e0832a845bf02a38111545)