### PR TITLE
feat(cli): Add CLI tool and export internal API functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
 
 jobs:
   test:
@@ -31,32 +33,3 @@ jobs:
 
       - name: Build server
         run: make build
-
-      # - name: Import data
-      #   run: make import-db
-
-      # - name: Start server
-      #   shell: bash
-      #   run: |
-      #     nohup ./build/daily-bible > server.log 2>&1 &
-      #     echo $! > server.pid
-      #     for i in $(seq 1 10); do
-      #       if curl -fsS http://127.0.0.1:8080/api/v1/random; then
-      #         echo "server ready"
-      #         break
-      #       fi
-      #       sleep 1
-      #     done
-      #     cat server.log
-
-      # - name: Run end-to-end tests
-      #   shell: bash
-      #   run: |
-      #     set -e
-      #     curl -fsS "http://127.0.0.1:8080/api/v1/random" | jq .
-      #     curl -fsS "http://127.0.0.1:8080/api/v1/search?q=Gi%C3%AAsu" | jq .
-      #     curl -fsS "http://127.0.0.1:8080/api/v1/gospel/Ga%2010,31-42" | jq .
-
-      # - name: Stop server
-      #   if: always()
-      #   run: kill $(cat server.pid) || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ go build -tags "fts5" ./...
 | Run tests | `make test` |
 | Tests with race detector | `make test-with-race-detector` |
 | Single test | `go test -tags "fts5" ./internal/api -run TestName` |
-| Build server binary | `make build` → `build/daily-bible` |
+| Build server binary | `make build` → `build/daily-bible-server` |
+| Build CLI binary | `make build-cli` → `build/daily-bible` |
 | Dev server | `make dev` (listens on `:8090`, override with `PORT=:8080`) |
 | CI lint | `staticcheck ./...` |
 
@@ -39,6 +40,16 @@ Vatican News sitemap → tools/crawler → build/gospels.txt → tools/tsv → b
 - **FTS**: `verses_fts` uses `unicode61 remove_diacritics 2` with prefix indexing, synced by triggers
 - **Connection pool**: `SetMaxOpenConns(1)` — SQLite is single-connection
 
+## CLI
+
+- `build/daily-bible today` — same as `GET /api/v1/today`
+- `build/daily-bible gospel <ref>` — same as `GET /api/v1/gospel/{ref}`
+- `build/daily-bible search <query>` — same as `GET /api/v1/search?q=...`
+- `build/daily-bible random` — same as `GET /api/v1/random`
+- `build/daily-bible <date>` — same as `GET /api/v1/date/{date}`
+- Uses same `DB_PATH` env var as the server
+- Outputs JSON to stdout
+
 ## API Layer
 
 - All routes wrapped in `corsMiddleware` then `loggingMiddleware`
@@ -52,6 +63,7 @@ Vatican News sitemap → tools/crawler → build/gospels.txt → tools/tsv → b
 
 ```
 cmd/server/main.go          — HTTP server entrypoint
+cmd/cli/main.go             — CLI entrypoint (`today`, `gospel`, `search`, `random`, date)
 internal/api/               — handlers, router, middleware
 internal/db/                — DB open + schema init
 internal/parser/            — HTML parsing (extracted from tools/crawler)

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,13 @@ setup-lectionary: ## Full lectionary setup (FILE=path or URL=https://...)
 	$(MAKE) import-calendar FILE=$(FILE) URL=$(URL)
 	$(MAKE) crawl-lectionary
 
-build: ## (5) Build the binary server file
+build: ## (5) Build the server binary
 	@mkdir -p build
-	go build $(GOFLAGS) -ldflags="-s -w" -o build/daily-bible ./cmd/server
+	go build $(GOFLAGS) -ldflags="-s -w" -o build/daily-bible-server ./cmd/server
+
+build-cli: ## Build the CLI binary
+	@mkdir -p build
+	go build $(GOFLAGS) -ldflags="-s -w" -o build/daily-bible ./cmd/cli
 
 dev: ## (6) Run the server in development mode (PORT=:8090)
 	@mkdir -p build

--- a/README.md
+++ b/README.md
@@ -90,7 +90,34 @@ DB_PATH=/path/to/bible.db make dev
 
 Server runs on `http://localhost:8090` by default.
 
-### 3) Call API endpoints
+### 3) Use the CLI tool
+
+Build the CLI:
+
+```shell
+make build-cli
+# or build manually:
+go build -tags "fts5" -o build/daily-bible ./cmd/cli
+```
+
+The CLI outputs JSON to stdout:
+
+```shell
+./build/daily-bible today
+./build/daily-bible 2026-03-22
+./build/daily-bible gospel "Ga 9,1-41"
+./build/daily-bible search "Chúa Giê-su"
+./build/daily-bible random
+./build/daily-bible help
+```
+
+Override the database path:
+
+```shell
+DB_PATH=/path/to/bible.db ./build/daily-bible today
+```
+
+### 4) Call API endpoints
 
 ```shell
 curl 'http://localhost:8090/api/v1/gospel/Ga%209,1-41'
@@ -181,7 +208,8 @@ make build
 | `make import-calendar FILE=...` | Import liturgical calendar JSON (override DB path with `DB_PATH`) |
 | `make crawl-lectionary` | Populate lectionary table from Vatican News |
 | `make setup-lectionary FILE=...` | Full lectionary setup (calendar + crawl) |
-| `make build` | Build server binary |
+| `make build` | Build server binary (`build/daily-bible-server`) |
+| `make build-cli` | Build CLI binary (`build/daily-bible`) |
 | `make dev` | Run server in development mode (default `:8090`) |
 | `make dev PORT=:8080` | Run server on custom port |
 | `make clean` | Clean build artifacts |

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/rand/v2"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/minh/daily-bible/internal/api"
+	"github.com/minh/daily-bible/internal/constants"
+	dbpkg "github.com/minh/daily-bible/internal/db"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+
+	cmd := os.Args[1]
+	if cmd == "help" || cmd == "-h" || cmd == "--help" {
+		usage()
+		return
+	}
+
+	dbPath := os.Getenv("DB_PATH")
+	if dbPath == "" {
+		dbPath = constants.DBPath
+	}
+
+	db, err := dbpkg.Open(dbPath)
+	if err != nil {
+		log.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	switch cmd {
+	case "today":
+		handleToday(ctx, db)
+	case "gospel":
+		if len(os.Args) < 3 {
+			log.Fatal("usage: daily-bible gospel <ref>")
+		}
+		handleGospel(ctx, db, os.Args[2])
+	case "search":
+		if len(os.Args) < 3 {
+			log.Fatal("usage: daily-bible search <query>")
+		}
+		handleSearch(ctx, db, os.Args[2])
+	case "random":
+		handleRandom(ctx, db)
+	default:
+		handleDate(ctx, db, cmd)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `Usage: daily-bible <command> [args]
+
+Commands:
+  today              Today's Gospel reading
+  gospel <ref>       Gospel verses by reference (e.g. "Ga 9,1-41")
+  search <query>     Full-text phrase search
+  random             Random verse
+  <date>             Gospel reading for a date (e.g. 2026-03-22)
+  help               Show this help
+`)
+}
+
+func handleToday(ctx context.Context, db *sql.DB) {
+	loc, err := time.LoadLocation(constants.Timezone)
+	if err != nil {
+		log.Printf("load timezone %q: %v, falling back to UTC", constants.Timezone, err)
+		loc = time.UTC
+	}
+	date := time.Now().In(loc).Format("2006-01-02")
+	outputDateReading(ctx, db, date)
+}
+
+func handleDate(ctx context.Context, db *sql.DB, date string) {
+	outputDateReading(ctx, db, date)
+}
+
+func outputDateReading(ctx context.Context, db *sql.DB, date string) {
+	var lectionaryKey, gospelRef string
+	err := db.QueryRowContext(ctx, `
+		SELECT c.lectionary_key, l.gospel_ref
+		FROM calendar c
+		JOIN lectionary l ON c.lectionary_key = l.lectionary_key
+		WHERE c.date = ?
+	`, date).Scan(&lectionaryKey, &gospelRef)
+
+	if err == sql.ErrNoRows {
+		log.Fatalf("no reading found for date %s", date)
+	}
+	if err != nil {
+		log.Fatalf("query error: %v", err)
+	}
+
+	verses, err := api.QueryByRef(ctx, db, gospelRef)
+	if err != nil {
+		log.Fatalf("verses query error for ref %q: %v", gospelRef, err)
+	}
+	if len(verses) == 0 {
+		log.Fatal("not found")
+	}
+
+	var sb strings.Builder
+	for _, v := range verses {
+		sb.WriteString(v.Text)
+		sb.WriteByte(' ')
+	}
+	combined := strings.TrimSpace(sb.String())
+
+	json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"date":           date,
+		"lectionary_key": lectionaryKey,
+		"ref":            gospelRef,
+		"verses":         combined,
+	})
+}
+
+func handleGospel(ctx context.Context, db *sql.DB, ref string) {
+	verses, err := api.QueryByRef(ctx, db, ref)
+	if err != nil {
+		log.Fatalf("query error: %v", err)
+	}
+	if len(verses) == 0 {
+		log.Fatal("not found")
+	}
+	json.NewEncoder(os.Stdout).Encode(verses)
+}
+
+func handleSearch(ctx context.Context, db *sql.DB, q string) {
+	if strings.TrimSpace(q) == "" {
+		log.Fatal("empty query")
+	}
+	if len(q) > 200 {
+		log.Fatal("query too long")
+	}
+
+	rows, err := db.QueryContext(ctx, `SELECT text FROM verses_fts WHERE verses_fts MATCH ? LIMIT 10`,
+		api.FtsPhraseQuery(q))
+	if err != nil {
+		log.Fatalf("search error: %v", err)
+	}
+	defer rows.Close()
+
+	var results []string
+	for rows.Next() {
+		var text string
+		if err := rows.Scan(&text); err != nil {
+			log.Printf("scan error: %v", err)
+			continue
+		}
+		results = append(results, text)
+	}
+	if err := rows.Err(); err != nil {
+		log.Fatalf("rows error: %v", err)
+	}
+	json.NewEncoder(os.Stdout).Encode(results)
+}
+
+func handleRandom(ctx context.Context, db *sql.DB) {
+	var maxRowID int64
+	if err := db.QueryRowContext(ctx, "SELECT IFNULL(MAX(rowid), 0) FROM verses").Scan(&maxRowID); err != nil {
+		log.Fatalf("query max rowid: %v", err)
+	}
+	if maxRowID <= 0 {
+		log.Fatal("no verses available")
+	}
+
+	var text string
+	for range 10 {
+		randomID := 1 + rand.Int64N(maxRowID)
+		row := db.QueryRowContext(ctx, "SELECT text FROM verses WHERE rowid = ?", randomID)
+		if err := row.Scan(&text); err != nil {
+			if err == sql.ErrNoRows {
+				continue
+			}
+			log.Fatalf("random query error: %v", err)
+		}
+		json.NewEncoder(os.Stdout).Encode(text)
+		return
+	}
+	log.Fatal("not found")
+}

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+var cliPath string
+
+func TestMain(m *testing.M) {
+	tmpDir, err := os.MkdirTemp("", "daily-bible-cli-test")
+	if err != nil {
+		os.Stderr.WriteString("setup: " + err.Error() + "\n")
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cliPath = filepath.Join(tmpDir, "daily-bible")
+	cmd := exec.Command("go", "build", "-tags", "fts5", "-o", cliPath, ".")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		os.Stderr.WriteString("build failed: " + err.Error() + "\n" + string(out) + "\n")
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+func applyMigrations(t *testing.T, database *sql.DB) {
+	t.Helper()
+	migrationsDir := "../../data/migrations"
+	entries, err := os.ReadDir(migrationsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() && len(e.Name()) > 0 && e.Name()[0] >= '0' && e.Name()[0] <= '9' {
+			content, err := os.ReadFile(filepath.Join(migrationsDir, e.Name()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := database.Exec(string(content)); err != nil {
+				t.Fatalf("apply migration %s: %v", e.Name(), err)
+			}
+		}
+	}
+}
+
+func setupTestDB(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "bible.db")
+
+	database, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	database.Exec("PRAGMA journal_mode=WAL;")
+	applyMigrations(t, database)
+
+	_, err = database.Exec(`
+		INSERT INTO verses (book, chapter, verse, verse_suffix, text) VALUES
+		('Ga', 11, 1, '', 'Now a man was ill...'),
+		('Ga', 11, 2, '', 'Mary was the one...'),
+		('Ga', 11, 45, '', 'Many of the Jews...')
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	today := time.Now().Format("2006-01-02")
+	_, err = database.Exec(`
+		INSERT INTO calendar (date, lectionary_key, season, sunday_cycle, weekday, weekday_cycle, week_of_season)
+		VALUES (?, 'lent_5_sun_A', 'lent', 'A', 'sun', '', 5)
+	`, today)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = database.Exec(`
+		INSERT INTO lectionary (lectionary_key, gospel_ref)
+		VALUES ('lent_5_sun_A', 'Ga 11,1-2')
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return dbPath
+}
+
+func runCLI(t *testing.T, dbPath string, args ...string) ([]byte, error) {
+	t.Helper()
+	cmd := exec.Command(cliPath, args...)
+	cmd.Env = append(os.Environ(), "DB_PATH="+dbPath)
+	return cmd.CombinedOutput()
+}
+
+func TestCLI_Help(t *testing.T) {
+	out, err := exec.Command(cliPath, "help").CombinedOutput()
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected help output")
+	}
+}
+
+func TestCLI_NoArgs(t *testing.T) {
+	err := exec.Command(cliPath).Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit for no args")
+	}
+}
+
+func TestCLI_Gospel(t *testing.T) {
+	dbPath := setupTestDB(t)
+	out, err := runCLI(t, dbPath, "gospel", "Ga 11,1-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+
+	var results []map[string]any
+	if err := json.Unmarshal(out, &results); err != nil {
+		t.Fatalf("json unmarshal: %v\nbody: %s", err, out)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 verses, got %d", len(results))
+	}
+	if results[0]["verse"] != float64(1) {
+		t.Fatalf("expected verse 1, got %v", results[0]["verse"])
+	}
+}
+
+func TestCLI_Gospel_NotFound(t *testing.T) {
+	dbPath := setupTestDB(t)
+	out, err := runCLI(t, dbPath, "gospel", "Ga 99,1-2")
+	if err == nil {
+		t.Fatal("expected error for not found gospel ref")
+	}
+	if string(out) == "" {
+		t.Fatal("expected error message on stderr")
+	}
+}
+
+func TestCLI_Date(t *testing.T) {
+	dbPath := setupTestDB(t)
+	today := time.Now().Format("2006-01-02")
+
+	out, err := runCLI(t, dbPath, today)
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("json unmarshal: %v\nbody: %s", err, out)
+	}
+	if result["date"] != today {
+		t.Fatalf("expected date %q, got %q", today, result["date"])
+	}
+	if result["lectionary_key"] != "lent_5_sun_A" {
+		t.Fatalf("unexpected lectionary_key: %v", result["lectionary_key"])
+	}
+}
+
+func TestCLI_Today(t *testing.T) {
+	dbPath := setupTestDB(t)
+	today := time.Now().Format("2006-01-02")
+
+	out, err := runCLI(t, dbPath, "today")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("json unmarshal: %v\nbody: %s", err, out)
+	}
+	if result["date"] != today {
+		t.Fatalf("expected date %q, got %q", today, result["date"])
+	}
+	if result["ref"] != "Ga 11,1-2" {
+		t.Fatalf("unexpected ref: %v", result["ref"])
+	}
+}
+
+func TestCLI_Date_NoData(t *testing.T) {
+	dbPath := setupTestDB(t)
+	out, err := runCLI(t, dbPath, "2099-01-01")
+	if err == nil {
+		t.Fatal("expected error for date with no reading")
+	}
+	if string(out) == "" {
+		t.Fatal("expected error message on stderr")
+	}
+}
+
+func TestCLI_Random(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	out, err := runCLI(t, dbPath, "random")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+
+	var text string
+	if err := json.Unmarshal(out, &text); err != nil {
+		t.Fatalf("json unmarshal: %v\nbody: %s", err, out)
+	}
+	if text == "" {
+		t.Fatal("expected non-empty random verse")
+	}
+}
+
+func TestCLI_Random_NoVerses(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "bible.db")
+	database, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	database.Exec("PRAGMA journal_mode=WAL;")
+	applyMigrations(t, database)
+
+	out, err := runCLI(t, dbPath, "random")
+	if err == nil {
+		t.Fatal("expected error for empty DB")
+	}
+	if string(out) == "" {
+		t.Fatal("expected error message on stderr")
+	}
+}
+
+func TestCLI_Search(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	out, err := runCLI(t, dbPath, "search", "man")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\noutput: %s", err, out)
+	}
+
+	var results []string
+	if err := json.Unmarshal(out, &results); err != nil {
+		t.Fatalf("json unmarshal: %v\nbody: %s", err, out)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one search result")
+	}
+}
+
+func TestCLI_Search_Empty(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	_, err := runCLI(t, dbPath, "search", "")
+	if err == nil {
+		t.Fatal("expected error for empty query")
+	}
+}
+
+func TestCLI_Search_TooLong(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	long := make([]byte, 201)
+	for i := range long {
+		long[i] = 'a'
+	}
+
+	out, err := runCLI(t, dbPath, "search", string(long))
+	if err == nil {
+		t.Fatal("expected error for long query")
+	}
+	if string(out) == "" {
+		t.Fatal("expected error message on stderr")
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -248,7 +248,7 @@ func makeSearchHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		rows, err := db.QueryContext(r.Context(), `SELECT text FROM verses_fts WHERE verses_fts MATCH ? LIMIT 10`,
-			ftsPhraseQuery(q))
+			FtsPhraseQuery(q))
 		if err != nil {
 			log.Printf("fts search error: %v", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -273,7 +273,7 @@ func makeSearchHandler(db *sql.DB) http.HandlerFunc {
 // ftsPhraseQuery wraps the query in double quotes for exact phrase matching in FTS5.
 // This is intentional: the search endpoint is designed for phrase-only search.
 // Users cannot search for individual tokens; the entire query is treated as a phrase.
-func ftsPhraseQuery(q string) string {
+func FtsPhraseQuery(q string) string {
 	escaped := strings.ReplaceAll(q, `"`, `""`)
 	return fmt.Sprintf(`"%s"`, escaped)
 }
@@ -359,7 +359,7 @@ func makeDateHandler(db *sql.DB, getDate func() string) http.HandlerFunc {
 			return
 		}
 
-		verses, err := queryByRef(r.Context(), db, gospelRef)
+		verses, err := QueryByRef(r.Context(), db, gospelRef)
 		if err != nil {
 			log.Printf("verses query error for ref %q: %v", gospelRef, err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)

--- a/internal/api/ref.go
+++ b/internal/api/ref.go
@@ -11,17 +11,17 @@ import (
 	"github.com/minh/daily-bible/internal/model"
 )
 
-type verseRange struct {
-	start       int
-	startSuffix string
-	end         int
-	endSuffix   string
+type VerseRange struct {
+	Start       int
+	StartSuffix string
+	End         int
+	EndSuffix   string
 }
 
 var refPattern = regexp.MustCompile(`^([A-Za-zÀ-ỹ]{1,3})\s+(\d+),(.+)$`)
 var segPattern = regexp.MustCompile(`(\d+)([a-zA-Z]?)(?:-(\d+)([a-zA-Z]?))?`)
 
-func parseRef(ref string) (book string, chapter int, ranges []verseRange, err error) {
+func ParseRef(ref string) (book string, chapter int, ranges []VerseRange, err error) {
 	m := refPattern.FindStringSubmatch(strings.TrimSpace(ref))
 	if m == nil {
 		return "", 0, nil, fmt.Errorf("invalid ref: %q", ref)
@@ -40,7 +40,7 @@ func parseRef(ref string) (book string, chapter int, ranges []verseRange, err er
 		if seg[3] != "" {
 			end, _ = strconv.Atoi(seg[3])
 		}
-		ranges = append(ranges, verseRange{start, startSuffix, end, endSuffix})
+		ranges = append(ranges, VerseRange{Start: start, StartSuffix: startSuffix, End: end, EndSuffix: endSuffix})
 	}
 	if len(ranges) == 0 {
 		return "", 0, nil, fmt.Errorf("no verse ranges in ref %q", ref)
@@ -48,8 +48,8 @@ func parseRef(ref string) (book string, chapter int, ranges []verseRange, err er
 	return
 }
 
-func queryByRef(ctx context.Context, db *sql.DB, ref string) ([]model.Gospel, error) {
-	book, chapter, ranges, err := parseRef(ref)
+func QueryByRef(ctx context.Context, db *sql.DB, ref string) ([]model.Gospel, error) {
+	book, chapter, ranges, err := ParseRef(ref)
 	if err != nil {
 		return nil, err
 	}
@@ -58,30 +58,30 @@ func queryByRef(ctx context.Context, db *sql.DB, ref string) ([]model.Gospel, er
 	var args []any
 	args = append(args, book, chapter)
 	for _, r := range ranges {
-		if r.startSuffix == "" && r.endSuffix == "" {
+		if r.StartSuffix == "" && r.EndSuffix == "" {
 			conditions = append(conditions, "(verse BETWEEN ? AND ? AND (verse_suffix = '' OR verse_suffix IS NULL))")
-			args = append(args, r.start, r.end)
-		} else if r.start == r.end {
-			if r.startSuffix != "" && r.endSuffix != "" {
+			args = append(args, r.Start, r.End)
+		} else if r.Start == r.End {
+			if r.StartSuffix != "" && r.EndSuffix != "" {
 				conditions = append(conditions, "(verse = ? AND verse_suffix >= ? AND verse_suffix <= ?)")
-				args = append(args, r.start, r.startSuffix, r.endSuffix)
-			} else if r.startSuffix != "" {
+				args = append(args, r.Start, r.StartSuffix, r.EndSuffix)
+			} else if r.StartSuffix != "" {
 				conditions = append(conditions, "(verse = ? AND verse_suffix >= ?)")
-				args = append(args, r.start, r.startSuffix)
+				args = append(args, r.Start, r.StartSuffix)
 			} else {
 				conditions = append(conditions, "(verse = ? AND verse_suffix <= ?)")
-				args = append(args, r.start, r.endSuffix)
+				args = append(args, r.Start, r.EndSuffix)
 			}
 		} else {
 			var innerClauses []string
 			var innerArgs []any
-			for v := r.start; v <= r.end; v++ {
-				if v == r.start && r.startSuffix != "" {
+			for v := r.Start; v <= r.End; v++ {
+				if v == r.Start && r.StartSuffix != "" {
 					innerClauses = append(innerClauses, "(verse = ? AND verse_suffix >= ?)")
-					innerArgs = append(innerArgs, v, r.startSuffix)
-				} else if v == r.end && r.endSuffix != "" {
+					innerArgs = append(innerArgs, v, r.StartSuffix)
+				} else if v == r.End && r.EndSuffix != "" {
 					innerClauses = append(innerClauses, "(verse = ? AND verse_suffix <= ?)")
-					innerArgs = append(innerArgs, v, r.endSuffix)
+					innerArgs = append(innerArgs, v, r.EndSuffix)
 				} else {
 					innerClauses = append(innerClauses, "(verse = ? AND (verse_suffix = '' OR verse_suffix IS NULL))")
 					innerArgs = append(innerArgs, v)

--- a/internal/api/ref_test.go
+++ b/internal/api/ref_test.go
@@ -43,29 +43,29 @@ func TestParseRef(t *testing.T) {
 		ref        string
 		wantBook   string
 		wantCh     int
-		wantRanges []verseRange
+		wantRanges []VerseRange
 		wantErr    bool
 	}{
 		{
 			ref:        "Ga 11,1-45",
 			wantBook:   "Ga",
 			wantCh:     11,
-			wantRanges: []verseRange{{start: 1, end: 45}},
+			wantRanges: []VerseRange{{Start: 1, End: 45}},
 		},
 		{
 			ref:      "Mt 5,20-22a.27-28",
 			wantBook: "Mt",
 			wantCh:   5,
-			wantRanges: []verseRange{
-				{start: 20, startSuffix: "", end: 22, endSuffix: "a"},
-				{start: 27, end: 28},
+			wantRanges: []VerseRange{
+				{Start: 20, StartSuffix: "", End: 22, EndSuffix: "a"},
+				{Start: 27, End: 28},
 			},
 		},
 		{
 			ref:        "Lc 1,1",
 			wantBook:   "Lc",
 			wantCh:     1,
-			wantRanges: []verseRange{{start: 1, end: 1}},
+			wantRanges: []VerseRange{{Start: 1, End: 1}},
 		},
 		{
 			ref:     "invalid",
@@ -79,7 +79,7 @@ func TestParseRef(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.ref, func(t *testing.T) {
-			book, chapter, ranges, err := parseRef(tc.ref)
+			book, chapter, ranges, err := ParseRef(tc.ref)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error for ref %q", tc.ref)
@@ -100,7 +100,7 @@ func TestParseRef(t *testing.T) {
 			}
 			for i, r := range ranges {
 				w := tc.wantRanges[i]
-				if r.start != w.start || r.end != w.end || r.startSuffix != w.startSuffix || r.endSuffix != w.endSuffix {
+				if r.Start != w.Start || r.End != w.End || r.StartSuffix != w.StartSuffix || r.EndSuffix != w.EndSuffix {
 					t.Errorf("range[%d]: got %+v, want %+v", i, r, w)
 				}
 			}
@@ -128,9 +128,9 @@ func TestQueryByRef(t *testing.T) {
 	}
 
 	t.Run("simple range", func(t *testing.T) {
-		verses, err := queryByRef(t.Context(), db, "Ga 11,1-3")
+		verses, err := QueryByRef(t.Context(), db, "Ga 11,1-3")
 		if err != nil {
-			t.Fatalf("queryByRef error: %v", err)
+			t.Fatalf("QueryByRef error: %v", err)
 		}
 		if len(verses) != 3 {
 			t.Fatalf("expected 3 verses, got %d", len(verses))
@@ -141,9 +141,9 @@ func TestQueryByRef(t *testing.T) {
 	})
 
 	t.Run("non-contiguous ranges", func(t *testing.T) {
-		verses, err := queryByRef(t.Context(), db, "Mt 5,20-22a.27-28")
+		verses, err := QueryByRef(t.Context(), db, "Mt 5,20-22a.27-28")
 		if err != nil {
-			t.Fatalf("queryByRef error: %v", err)
+			t.Fatalf("QueryByRef error: %v", err)
 		}
 		if len(verses) != 5 {
 			t.Fatalf("expected 5 verses, got %d: %+v", len(verses), verses)
@@ -162,9 +162,9 @@ func TestQueryByRef(t *testing.T) {
 	})
 
 	t.Run("single verse", func(t *testing.T) {
-		verses, err := queryByRef(t.Context(), db, "Ga 11,45-45")
+		verses, err := QueryByRef(t.Context(), db, "Ga 11,45-45")
 		if err != nil {
-			t.Fatalf("queryByRef error: %v", err)
+			t.Fatalf("QueryByRef error: %v", err)
 		}
 		if len(verses) != 1 {
 			t.Fatalf("expected 1 verse, got %d", len(verses))


### PR DESCRIPTION
- New cmd/cli/main.go with subcommands: today, gospel, search, random, date
- Refactored tests at cmd/cli/main_test.go with 12 integration tests
- Exported ParseRef, QueryByRef, VerseRange, FtsPhraseQuery in internal/api
- Added make build-cli target to build the CLI binary
- Updated README.md and AGENTS.md with CLI usage and package structure