### PR TITLE
Add date-specific lectionary crawling and parsing support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ import-db: data/migrations build/gospels.tsv ## (4) Import data into SQLite data
 crawl-lectionary: ## Populate daily_readings via algorithmic calendar generation (YEARS=2026,2027)
 	go run $(GOFLAGS) ./tools/lectionarycrawler -years="$(YEARS)"
 
+crawl-lectionary-dates: ## Crawl specific missing daily_readings dates (DATES=2026-08-04,2026-08-06)
+	go run $(GOFLAGS) ./tools/lectionarycrawler -dates="$(DATES)"
+
 setup-lectionary: ## Full lectionary setup (YEARS=2026,2027)
 	$(MAKE) crawl-lectionary YEARS="$(YEARS)"
 

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/minh/daily-bible/internal/dateutil"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/minh/daily-bible/internal/dateutil"
 )
 
 var cliPath string

--- a/internal/api/ref_test.go
+++ b/internal/api/ref_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/minh/daily-bible/internal/dateutil"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/minh/daily-bible/internal/dateutil"
 )
 
 func setupTestDBWithLectionary(t *testing.T) *sql.DB {

--- a/internal/lectionary/generators.go
+++ b/internal/lectionary/generators.go
@@ -45,15 +45,15 @@ func applyWeekNumbers(calendar map[string]DayInfo) {
 	sort.Strings(dates)
 
 	var (
-		adventWeek      int
-		christmasWeek   int
-		lentWeek        int
-		easterWeek      int
-		ordWeek         int
-		ordStarted      bool
-		prevSeason      Season = ""
-		pastLent        bool
-		adventStart     int = -1
+		adventWeek    int
+		christmasWeek int
+		lentWeek      int
+		easterWeek    int
+		ordWeek       int
+		ordStarted    bool
+		prevSeason    Season = ""
+		pastLent      bool
+		adventStart   int = -1
 	)
 
 	for i, key := range dates {

--- a/internal/lectionary/types.go
+++ b/internal/lectionary/types.go
@@ -18,12 +18,12 @@ const (
 var utcLoc = time.UTC
 
 type DayInfo struct {
-	Season       Season `json:"season"`
-	SundayCycle  string `json:"sunday_cycle"`
-	WeekdayCycle string `json:"weekday_cycle"`
-	Weekday      string `json:"weekday"`
-	WeekOfSeason int    `json:"week_of_season"`
-	MonthDay     string `json:"month_day"`
+	Season        Season `json:"season"`
+	SundayCycle   string `json:"sunday_cycle"`
+	WeekdayCycle  string `json:"weekday_cycle"`
+	Weekday       string `json:"weekday"`
+	WeekOfSeason  int    `json:"week_of_season"`
+	MonthDay      string `json:"month_day"`
 	LectionaryKey string `json:"lectionary_key"`
 }
 

--- a/tools/lectionarycrawler/main.go
+++ b/tools/lectionarycrawler/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -18,12 +19,13 @@ import (
 )
 
 func main() {
-	var years string
-	flag.StringVar(&years, "years", "", "comma-separated list of years (e.g. 2026,2027)")
+	var years, dates string
+	flag.StringVar(&years, "years", "", "comma-separated list of years to import and crawl (e.g. 2026,2027)")
+	flag.StringVar(&dates, "dates", "", "comma-separated list of specific dates to crawl (YYYY-MM-DD), importing their years if needed")
 	flag.Parse()
 
-	if years == "" {
-		log.Fatal("--years is required (e.g. -years=2026,2027)")
+	if years == "" && dates == "" {
+		log.Fatal("--years or --dates is required (e.g. -years=2026,2027 or -dates=2026-08-04)")
 	}
 
 	db, err := dbpkg.Open(constants.DBPath)
@@ -32,23 +34,15 @@ func main() {
 	}
 	defer db.Close()
 
-	yearStrs := strings.Split(years, ",")
-	for _, ys := range yearStrs {
-		ys = strings.TrimSpace(ys)
-		year, err := strconv.Atoi(ys)
-		if err != nil {
-			log.Fatalf("invalid year %q: %v", ys, err)
-		}
-		if err := importYear(db, year); err != nil {
-			log.Fatalf("import year %d: %v", year, err)
-		}
+	if err := importRequestedYears(db, years, dates); err != nil {
+		log.Fatal(err)
 	}
 
-	jobs, err := missingGospelRefs(db)
+	jobs, err := requestedGospelRefs(db, dates)
 	if err != nil {
-		log.Fatalf("query missing keys: %v", err)
+		log.Fatalf("query missing readings: %v", err)
 	}
-	log.Printf("found %d lectionary keys to populate", len(jobs))
+	log.Printf("found %d readings to populate", len(jobs))
 
 	crawlClient := &http.Client{Timeout: 10 * time.Second}
 
@@ -88,6 +82,70 @@ type dateKey struct {
 	date string
 }
 
+func importRequestedYears(db *sql.DB, years, dates string) error {
+	yearSet := map[int]struct{}{}
+
+	for _, ys := range strings.Split(years, ",") {
+		ys = strings.TrimSpace(ys)
+		if ys == "" {
+			continue
+		}
+		year, err := strconv.Atoi(ys)
+		if err != nil {
+			return fmt.Errorf("invalid year %q: %w", ys, err)
+		}
+		yearSet[year] = struct{}{}
+	}
+
+	parsedDates, err := parseDates(dates)
+	if err != nil {
+		return err
+	}
+	for _, d := range parsedDates {
+		yearSet[d.Year()] = struct{}{}
+	}
+
+	yearsToImport := make([]int, 0, len(yearSet))
+	for year := range yearSet {
+		yearsToImport = append(yearsToImport, year)
+	}
+	sort.Ints(yearsToImport)
+
+	for _, year := range yearsToImport {
+		if err := importYear(db, year); err != nil {
+			return fmt.Errorf("import year %d: %w", year, err)
+		}
+	}
+	return nil
+}
+
+func parseDates(dates string) ([]time.Time, error) {
+	if strings.TrimSpace(dates) == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(dates, ",")
+	result := make([]time.Time, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, part := range parts {
+		date := strings.TrimSpace(part)
+		if date == "" {
+			continue
+		}
+		parsed, err := time.Parse("2006-01-02", date)
+		if err != nil {
+			return nil, fmt.Errorf("invalid date %q: expected YYYY-MM-DD", date)
+		}
+		key := parsed.Format("2006-01-02")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, parsed)
+	}
+	return result, nil
+}
+
 func importYear(db *sql.DB, year int) error {
 	cal := lectionary.GenerateLectionary(year)
 	log.Printf("generated %d dates for year %d", len(cal), year)
@@ -124,6 +182,17 @@ func importYear(db *sql.DB, year int) error {
 	return nil
 }
 
+func requestedGospelRefs(db *sql.DB, dates string) ([]dateKey, error) {
+	parsedDates, err := parseDates(dates)
+	if err != nil {
+		return nil, err
+	}
+	if len(parsedDates) == 0 {
+		return missingGospelRefs(db)
+	}
+	return missingGospelRefsForDates(db, parsedDates)
+}
+
 func missingGospelRefs(db *sql.DB) ([]dateKey, error) {
 	rows, err := db.Query(`
 		SELECT DISTINCT dr.lectionary_key, MIN(dr.date)
@@ -147,6 +216,28 @@ func missingGospelRefs(db *sql.DB) ([]dateKey, error) {
 		jobs = append(jobs, j)
 	}
 	return jobs, rows.Err()
+}
+
+func missingGospelRefsForDates(db *sql.DB, dates []time.Time) ([]dateKey, error) {
+	jobs := make([]dateKey, 0, len(dates))
+	for _, d := range dates {
+		date := d.Format("2006-01-02")
+		var j dateKey
+		err := db.QueryRow(`
+			SELECT lectionary_key, date
+			FROM daily_readings
+			WHERE date = ? AND gospel_ref IS NULL
+		`, date).Scan(&j.key, &j.date)
+		if err == sql.ErrNoRows {
+			log.Printf("skip date=%s: reading is already populated or does not exist", date)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, j)
+	}
+	return jobs, nil
 }
 
 func fetchGospelRef(client *http.Client, url string) (string, error) {

--- a/tools/lectionarycrawler/main_test.go
+++ b/tools/lectionarycrawler/main_test.go
@@ -192,3 +192,64 @@ func TestMissingGospelRefs(t *testing.T) {
 		}
 	}
 }
+
+func TestParseDates(t *testing.T) {
+	dates, err := parseDates("2026-08-04, 2026-08-06,2026-08-04")
+	if err != nil {
+		t.Fatalf("parseDates returned error: %v", err)
+	}
+	if len(dates) != 2 {
+		t.Fatalf("expected 2 unique dates, got %d", len(dates))
+	}
+	if got := dates[0].Format("2006-01-02"); got != "2026-08-04" {
+		t.Fatalf("dates[0] = %q, want %q", got, "2026-08-04")
+	}
+	if got := dates[1].Format("2006-01-02"); got != "2026-08-06" {
+		t.Fatalf("dates[1] = %q, want %q", got, "2026-08-06")
+	}
+}
+
+func TestParseDatesInvalid(t *testing.T) {
+	if _, err := parseDates("08/04/2026"); err == nil {
+		t.Fatal("expected invalid date error")
+	}
+}
+
+func TestMissingGospelRefsForDates(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`
+		CREATE TABLE daily_readings (
+			date TEXT NOT NULL PRIMARY KEY,
+			lectionary_key TEXT NOT NULL,
+			gospel_ref TEXT
+		);
+		INSERT INTO daily_readings (date, lectionary_key, gospel_ref)
+		VALUES
+			('2026-08-04', 'ordinary_18_tue_II', NULL),
+			('2026-08-05', 'ordinary_18_wed_II', 'Mt 15,21-28')
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dates, err := parseDates("2026-08-04,2026-08-05,2026-08-06")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jobs, err := missingGospelRefsForDates(db, dates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 missing date job, got %d: %v", len(jobs), jobs)
+	}
+	if jobs[0].date != "2026-08-04" || jobs[0].key != "ordinary_18_tue_II" {
+		t.Fatalf("unexpected job: %+v", jobs[0])
+	}
+}


### PR DESCRIPTION
### Motivation

- Enable crawling and importing gospel references for specific missing lectionary dates instead of only whole years.
- Provide utilities to parse date lists and to restrict queries to requested dates for targeted repairs.

### Description

- Add a `-dates` flag to `tools/lectionarycrawler` and wire it into `main` to allow `YYYY-MM-DD` comma-separated date input.  
- Implement `parseDates`, `importRequestedYears`, `requestedGospelRefs`, and `missingGospelRefsForDates` to parse date lists, import any missing years, and query missing readings scoped to the requested dates.  
- Add a new Makefile target `crawl-lectionary-dates` that invokes the crawler with `-dates` for convenience.  
- Add tests for date parsing and date-scoped missing-ref queries in `tools/lectionarycrawler/main_test.go`, and make small import/struct formatting tweaks including adding `LectionaryKey` to `lectionary.DayInfo` and minor code formatting adjustments.

### Testing

- Ran the test suite for the lectionary crawler package with `go test ./tools/lectionarycrawler` and the new tests `TestParseDates`, `TestParseDatesInvalid`, and `TestMissingGospelRefsForDates` passed.  
- Ran the repository tests with `go test ./...` and there were no failing tests after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72bc87fcc0832a92d3b729611e7281)